### PR TITLE
Array.unsafe set length

### DIFF
--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -291,6 +291,19 @@ class Array[A] is Seq[A]
     """
     ArrayPairs[A, this->Array[A]](this)
 
+  fun ref unsafe_set_length(len: U64): Array[A]^ ? =>
+    """
+    DO NOT USE in Pony code. Solely for FFI interaction.
+    Forcefully set a size of an array.
+    """
+    if len < _alloc then
+      _size = len
+    else
+      error
+    end
+
+    this
+
 class ArrayKeys[A, B: Array[A] box] is Iterator[U64]
   let _array: B
   var _i: U64

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -296,7 +296,7 @@ class Array[A] is Seq[A]
     DO NOT USE in Pony code. Solely for FFI interaction.
     Forcefully set a size of an array.
     """
-    if len < _alloc then
+    if len <= _alloc then
       _size = len
     else
       error


### PR DESCRIPTION
Method is used to set the length of Array instance when interacting
with FFI through pointer, acquired with Array.cstring()

The scenario is common when interfacing with C libraries that do
no allocations themselves, but instead rely on the caller to
allocate memory and tell it's size.

Example Pony source. NOT a valid Pony for now. Contains proposed `unsafe_set_length()` call.

    use "lib:fill_array"
    
    actor Main
      new create(env: Env) =>
        let len: U64 = 100
        var foo: Array[I32] = Array[I32](len)
    
        let result = @fill_array[U64](foo.cstring(), len)
    
        try
          foo.unsafe_set_length(result.u64())
        end
    
        for v in foo.values() do
          env.out.print(v.string())
        end

Example C source library function.

    #include <stdint.h>
    
    uint64_t fill_array(int32_t *array, uint64_t size) {
      int i = 0;
      for (i = 0; i < size; i++) {
        array[i] = 1 + (i * i);
      }
    
      return i;
    }
Ready to compile sources can be found here: https://github.com/d3m1gd/unsafe-length-array-proposal