### PR TITLE
Add default values to last argument in some String methods.

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -400,7 +400,7 @@ class String val is Seq[U8], Ordered[String box], Stringable
 
     i
 
-  fun at(s: String box, offset: I64): Bool =>
+  fun at(s: String box, offset: I64 = 0): Bool =>
     """
     Returns true if the substring s is present at the given offset.
     """
@@ -412,7 +412,7 @@ class String val is Seq[U8], Ordered[String box], Stringable
       false
     end
 
-  fun ref delete(offset: I64, len: U64): String ref^ =>
+  fun ref delete(offset: I64, len: U64 = 1): String ref^ =>
     """
     Delete len bytes at the supplied offset, compacting the string in place.
     """
@@ -426,7 +426,7 @@ class String val is Seq[U8], Ordered[String box], Stringable
     end
     this
 
-  fun substring(from: I64, to: I64): String iso^ =>
+  fun substring(from: I64, to: I64 = -1): String iso^ =>
     """
     Returns a substring. From and to are inclusive. Returns an empty string if
     nothing is in the range.
@@ -643,7 +643,7 @@ class String val is Seq[U8], Ordered[String box], Stringable
     _set(_size, 0)
     this
 
-  fun cut(from: I64, to: I64): String iso^ =>
+  fun cut(from: I64, to: I64 = -1): String iso^ =>
     """
     Returns a version of the string with the given range deleted. The range is
     inclusive.
@@ -652,7 +652,7 @@ class String val is Seq[U8], Ordered[String box], Stringable
     s.cut_in_place(from, to)
     s
 
-  fun ref cut_in_place(from: I64, to: I64): String ref^ =>
+  fun ref cut_in_place(from: I64, to: I64 = -1): String ref^ =>
     """
     Cuts the given range out of the string.
     """


### PR DESCRIPTION
There are some two-argument String methods that could benefit from having the second argument be optional, as there is a sensible "default" value that applies implicitly to a wide variety of cases.

Specifically, these methods:
- `String.at` - default to use `offset = 0`
- `String.delete` - default to use `len = 1`
- `String.substring` - default to use `to = -1` (to end of string)
- `String.cut` - default to use `to = -1` (to end of string)
- `String.cut_in_place` - default to use `to = -1` (to end of string)

This PR introduces those default values to enhance the usability of the API without breaking compatibility for any existing code.