### PR TITLE
Fix os_accept to handle `ns==-1`, `errno==EAGAIN`.

### DIFF
--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -708,12 +708,15 @@ PONYFD os_accept(asio_event_t* ev)
   iocp_accept(ev);
 #elif defined(PLATFORM_IS_LINUX)
   SOCKET ns = accept4((SOCKET)ev->data, NULL, NULL, SOCK_NONBLOCK);
+
+  if(ns == -1 && (errno == EWOULDBLOCK || errno == EAGAIN))
+    ns = 0;
 #else
   SOCKET ns = accept((SOCKET)ev->data, NULL, NULL);
 
   if(ns != -1)
     set_nonblocking(ns);
-  else if(errno == EWOULDBLOCK)
+  else if(errno == EWOULDBLOCK || errno == EAGAIN)
     ns = 0;
 #endif
 


### PR DESCRIPTION
This was causing an endless loop and system churn in the
`TCPListener._accept` function when running on systems where
errno is set to `EAGAIN` from `accept` or `accept4`.

From [the man page for `accept4`](http://linux.die.net/man/2/accept4):
> `EAGAIN` or `EWOULDBLOCK`
    The socket is marked nonblocking and no connections are present to be accepted. POSIX.1-2001 allows either error to be returned for this case, and does not require these constants to have the same value, so a portable application should check for both possibilities. 