### PR TITLE
Change clone method of collections to consistently return iso^.

### DIFF
--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -276,11 +276,12 @@ class Array[A] is Seq[A]
 
     error
 
-  fun clone(): Array[this->A!]^ =>
+  fun clone(): Array[this->A!] iso^ =>
     """
     Clone the array.
     """
-    let out = Array[this->A!](_size)
+    let size' = _size
+    let out = recover iso Array[this->A!](size') end
     _ptr._copy_to(out._ptr, _size)
     out
 

--- a/packages/collections/list.pony
+++ b/packages/collections/list.pony
@@ -190,11 +190,11 @@ class List[A] is Seq[A]
 
     this
 
-  fun clone(): List[this->A!]^ =>
+  fun clone(): List[this->A!] iso^ =>
     """
     Clone the list.
     """
-    let out = List[this->A!]
+    let out = recover iso List[this->A!] end
 
     for v in values() do
       out.push(v)

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -175,13 +175,14 @@ class HashMap[K, V, H: HashFunction[K] val]
     this
 
   fun clone[H2: HashFunction[this->K!] val = H]():
-    HashMap[this->K!, this->V!, H2]^
+    HashMap[this->K!, this->V!, H2] iso^
   =>
     """
     Create a clone. The key and value types may be different due to aliasing
     and viewpoint adaptation.
     """
-    let r = HashMap[this->K!, this->V!, H2](_size)
+    let size' = _size
+    let r = recover iso HashMap[this->K!, this->V!, H2](size') end
 
     for (k, v) in pairs() do
       r(k) = v

--- a/packages/collections/set.pony
+++ b/packages/collections/set.pony
@@ -215,12 +215,13 @@ class HashSet[A, H: HashFunction[A!] val] is Ordered[HashSet[A, H] box]
     end
     r
 
-  fun clone[K: HashFunction[this->A!] val = H](): HashSet[this->A!, K]^ =>
+  fun clone[K: HashFunction[this->A!] val = H](): HashSet[this->A!, K] iso^ =>
     """
     Create a clone. The element type may be different due to aliasing and
     viewpoint adaptation.
     """
-    let r = HashSet[this->A!, K](size())
+    let size' = size()
+    let r = recover HashSet[this->A!, K](size') end
 
     for value in values() do
       r.set(value)


### PR DESCRIPTION
This PR changes the `clone` method of `Array`, `List`, `HashMap`, and `HashSet` to return `iso^`.

This is a more flexible return type, allowing the calling code to take advantage of the fact that the return value is indeed the only reference to the new object that exists so far.  This is also more consistent the `clone` method signature for `String` and `Flags`, which already do this. 