### PR TITLE
FileMode.group() and FileMode.private() now set the any_exec bit

### DIFF
--- a/packages/files/filemode.pony
+++ b/packages/files/filemode.pony
@@ -43,7 +43,7 @@ class FileMode
     """
     any_read = false
     any_write = false
-    any_read = false
+    any_exec = false
     this
 
   fun ref private(): FileMode =>
@@ -55,7 +55,7 @@ class FileMode
     group_exec = false
     any_read = false
     any_write = false
-    any_read = false
+    any_exec = false
     this
 
   fun _os(): U32 =>


### PR DESCRIPTION
Before any_read has instead been set twice.