### PR TITLE
Rename builtin type Event as AsioEvent.

### DIFF
--- a/packages/builtin/asioevent.pony
+++ b/packages/builtin/asioevent.pony
@@ -1,17 +1,17 @@
-type EventID is Pointer[Event] tag
+type AsioEventID is Pointer[AsioEvent] tag
 
-interface EventNotify tag
-  be _event_notify(event: EventID, flags: U32, arg: U64)
+interface AsioEventNotify tag
+  be _event_notify(event: AsioEventID, flags: U32, arg: U64)
 
-primitive Event
+primitive AsioEvent
   """
   Functions for asynchronous event notification.
   """
-  fun none(): EventID =>
+  fun none(): AsioEventID =>
     """
     An empty event.
     """
-    Pointer[Event]
+    Pointer[AsioEvent]
 
   fun readable(flags: U32): Bool =>
     """

--- a/packages/builtin/stdin.pony
+++ b/packages/builtin/stdin.pony
@@ -26,7 +26,7 @@ actor Stdin
   access is provided only via an environment.
   """
   var _notify: (StdinNotify | None) = None
-  var _event: EventID = Event.none()
+  var _event: AsioEventID = AsioEvent.none()
   let _use_event: Bool
 
   new _create(use_event: Bool) =>
@@ -55,12 +55,12 @@ actor Stdin
       if _use_event and not _event.is_null() then
         // Unsubscribe the event.
         @asio_event_unsubscribe[None](_event)
-        _event = Event.none()
+        _event = AsioEvent.none()
       end
     elseif _notify is None then
       if _use_event then
         // Create a new event.
-        _event = @asio_event_create[Pointer[Event]](this, U64(0), U32(1), true)
+        _event = @asio_event_create[Pointer[AsioEvent]](this, U64(0), U32(1), true)
       else
         // Start the read loop.
         _loop_read()
@@ -78,13 +78,13 @@ actor Stdin
       _loop_read()
     end
 
-  be _event_notify(event: EventID, flags: U32, arg: U64) =>
+  be _event_notify(event: AsioEventID, flags: U32, arg: U64) =>
     """
     When the event fires, read from stdin.
     """
-    if Event.disposable(flags) then
+    if AsioEvent.disposable(flags) then
       @asio_event_destroy[None](event)
-    elseif (_event is event) and Event.readable(flags) then
+    elseif (_event is event) and AsioEvent.readable(flags) then
       _read()
     end
 
@@ -152,5 +152,5 @@ actor Stdin
       """
       if not _event.is_null() then
         @asio_event_unsubscribe[None](_event)
-        _event = Event.none()
+        _event = AsioEvent.none()
       end

--- a/packages/net/tcplistener.pony
+++ b/packages/net/tcplistener.pony
@@ -4,7 +4,7 @@ actor TCPListener
   """
   var _notify: TCPListenNotify
   var _fd: U64
-  var _event: EventID = Event.none()
+  var _event: AsioEventID = AsioEvent.none()
   var _closed: Bool = false
   let _limit: U64
   var _count: U64 = 0
@@ -18,7 +18,7 @@ actor TCPListener
     """
     _limit = limit
     _notify = consume notify
-    _event = @os_listen_tcp[EventID](this, host.cstring(), service.cstring())
+    _event = @os_listen_tcp[AsioEventID](this, host.cstring(), service.cstring())
     _fd = @asio_event_data[U64](_event)
     _notify_listening()
 
@@ -30,7 +30,7 @@ actor TCPListener
     """
     _limit = limit
     _notify = consume notify
-    _event = @os_listen_tcp4[EventID](this, host.cstring(), service.cstring())
+    _event = @os_listen_tcp4[AsioEventID](this, host.cstring(), service.cstring())
     _fd = @asio_event_data[U64](_event)
     _notify_listening()
 
@@ -42,7 +42,7 @@ actor TCPListener
     """
     _limit = limit
     _notify = consume notify
-    _event = @os_listen_tcp6[EventID](this, host.cstring(), service.cstring())
+    _event = @os_listen_tcp6[AsioEventID](this, host.cstring(), service.cstring())
     _fd = @asio_event_data[U64](_event)
     _notify_listening()
 
@@ -66,7 +66,7 @@ actor TCPListener
     @os_sockname[Bool](_fd, ip)
     ip
 
-  be _event_notify(event: EventID, flags: U32, arg: U64) =>
+  be _event_notify(event: AsioEventID, flags: U32, arg: U64) =>
     """
     When we are readable, we accept new connections until none remain.
     """
@@ -74,13 +74,13 @@ actor TCPListener
       return
     end
 
-    if Event.readable(flags) then
+    if AsioEvent.readable(flags) then
       _accept(arg)
     end
 
-    if Event.disposable(flags) then
+    if AsioEvent.disposable(flags) then
       @asio_event_destroy[None](_event)
-      _event = Event.none()
+      _event = AsioEvent.none()
     end
 
   be _conn_closed() =>

--- a/packages/net/udpsocket.pony
+++ b/packages/net/udpsocket.pony
@@ -3,7 +3,7 @@ use "collections"
 actor UDPSocket
   var _notify: UDPNotify
   var _fd: U64
-  var _event: EventID
+  var _event: AsioEventID
   var _readable: Bool = false
   var _closed: Bool = false
   var _packet_size: U64
@@ -17,7 +17,7 @@ actor UDPSocket
     Listens for both IPv4 and IPv6 datagrams.
     """
     _notify = consume notify
-    _event = @os_listen_udp[EventID](this, host.cstring(), service.cstring())
+    _event = @os_listen_udp[AsioEventID](this, host.cstring(), service.cstring())
     _fd = @asio_event_data[U64](_event)
     _packet_size = size
     _notify_listening()
@@ -30,7 +30,7 @@ actor UDPSocket
     Listens for IPv4 datagrams.
     """
     _notify = consume notify
-    _event = @os_listen_udp4[EventID](this, host.cstring(), service.cstring())
+    _event = @os_listen_udp4[AsioEventID](this, host.cstring(), service.cstring())
     _fd = @asio_event_data[U64](_event)
     _packet_size = size
     _notify_listening()
@@ -43,7 +43,7 @@ actor UDPSocket
     Listens for IPv6 datagrams.
     """
     _notify = consume notify
-    _event = @os_listen_udp6[EventID](this, host.cstring(), service.cstring())
+    _event = @os_listen_udp6[AsioEventID](this, host.cstring(), service.cstring())
     _fd = @asio_event_data[U64](_event)
     _packet_size = size
     _notify_listening()
@@ -120,7 +120,7 @@ actor UDPSocket
     @os_sockname[Bool](_fd, ip)
     ip
 
-  be _event_notify(event: EventID, flags: U32, arg: U64) =>
+  be _event_notify(event: AsioEventID, flags: U32, arg: U64) =>
     """
     When we are readable, we accept new connections until none remain.
     """
@@ -131,19 +131,19 @@ actor UDPSocket
     if not _closed then
       _event = event
 
-      if Event.readable(flags) then
+      if AsioEvent.readable(flags) then
         _readable = true
         _complete_reads(arg)
         _pending_reads()
       end
-    elseif Platform.windows() and Event.readable(flags) then
+    elseif Platform.windows() and AsioEvent.readable(flags) then
       _readable = false
       _close()
     end
 
-    if Event.disposable(flags) then
+    if AsioEvent.disposable(flags) then
       @asio_event_destroy[None](_event)
-      _event = Event.none()
+      _event = AsioEvent.none()
     end
 
   be _read_again() =>

--- a/packages/time/timers.pony
+++ b/packages/time/timers.pony
@@ -9,7 +9,7 @@ actor Timers
   let _map: MapIs[Timer tag, Timer] = MapIs[Timer tag, Timer]
   let _wheel: Array[_TimingWheel] = Array[_TimingWheel](_wheels())
   let _pending: List[Timer] = List[Timer]
-  var _event: EventID = Event.none()
+  var _event: AsioEventID = AsioEvent.none()
 
   new create(slop: U64 = 20) =>
     """
@@ -47,7 +47,7 @@ actor Timers
       if (_map.size() == 0) and (not _event.is_null()) then
         // Unsubscribe an existing event.
         @asio_event_unsubscribe[None](_event)
-        _event = Event.none()
+        _event = AsioEvent.none()
       end
     end
 
@@ -62,14 +62,14 @@ actor Timers
 
     if not _event.is_null() then
       @asio_event_unsubscribe[None](_event)
-      _event = Event.none()
+      _event = AsioEvent.none()
     end
 
-  be _event_notify(event: EventID, flags: U32, arg: U64) =>
+  be _event_notify(event: AsioEventID, flags: U32, arg: U64) =>
     """
     When the event fires, advance the timing wheels.
     """
-    if Event.disposable(flags) then
+    if AsioEvent.disposable(flags) then
       @asio_event_destroy[None](event)
     elseif event is _event then
       _advance()
@@ -101,7 +101,7 @@ actor Timers
     if _event.is_null() then
       if nsec != -1 then
         // Create a new event.
-        _event = @asio_event_create[Pointer[Event]](this, nsec, U32(4), true)
+        _event = @asio_event_create[Pointer[AsioEvent]](this, nsec, U32(4), true)
       end
     else
       if nsec != -1 then
@@ -110,7 +110,7 @@ actor Timers
       else
         // Unsubscribe an existing event.
         @asio_event_unsubscribe[None](_event)
-        _event = Event.none()
+        _event = AsioEvent.none()
       end
     end
 


### PR DESCRIPTION
The Event type is integral to the builtin (and not builtin) I/O types, so it makes complete sense that it's a builtin type, but I would say that you have to be very careful about naming builtin types, because they are the only names that a user can never use as a type name in their own packages.

In this case, I feel that `AsioEvent` (or perhaps, `IOEvent`) does a better job at describing how this type is used (it is not a generic "event", but is specifically related to IO and the `asio_event_` set of functions, and corresponds to the `asio_event_t` C type), and also leaves the name `Event` open for types in other packages (think `mypackage.Event`, using the namespaced variant of the `use` statements).

If you disagree with this suggestion, feel free to close this.