### PR TITLE
Correct "OSX" to "OS X".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Fixed
 
 - ANSI stripping on zero length writes to stdout/stderr.
-- More OSX 10.8 compatibility.
+- More OS X 10.8 compatibility.
 - SSL multithreading support.
 - Nested tuple code generation.
 - Only finalise blocked actors when detecting quiescence.
@@ -76,7 +76,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
-- OSX 10.8 compatibility.
+- OS X 10.8 compatibility.
 
 ## [0.1.4] - 2015-05-14
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 # Installation
 
-## Mac OSX using [Homebrew](http://brew.sh)
+## Mac OS X using [Homebrew](http://brew.sh)
 
 ```bash
 $ brew update 
@@ -127,7 +127,7 @@ $ make config=release
 $ ./build/release/ponyc examples/helloworld
 ```
 
-# Building on Mac OSX
+# Building on Mac OS X
 
 First, install [homebrew](http://brew.sh) if you haven't already. Then, brew llvm36, like this:
 

--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -17,7 +17,7 @@ class Directory
   Operations on a directory.
 
   The directory-relative functions (open, etc) use the *at interface on FreeBSD
-  and Linux. This isn't available on OSX prior to 10.10, so it is not used. On
+  and Linux. This isn't available on OS X prior to 10.10, so it is not used. On
   FreeBSD, this allows the directory-relative functions to take advantage of
   Capsicum.
   """


### PR DESCRIPTION
"Mac OS X"/"OS X" should be spelled with a space before the "X". Please pull.