### PR TITLE
remove Platform.freebsd() constraints around capsicum FFI

### DIFF
--- a/packages/capsicum/caprights.pony
+++ b/packages/capsicum/caprights.pony
@@ -41,62 +41,42 @@ class CapRights0
     """
     Initialises with the rights on the given file descriptor.
     """
-    if Platform.freebsd() then
-      @__cap_rights_get[Pointer[U64]](I32(0), fd, &_r0)
-    end
+    @__cap_rights_get[Pointer[U64]](I32(0), fd, &_r0)
 
   fun ref set(cap: U64): CapRights0^ =>
-    if Platform.freebsd() then
-      @__cap_rights_set[Pointer[U64]](&_r0, cap, U64(0))
-    end
+    @__cap_rights_set[Pointer[U64]](&_r0, cap, U64(0))
     this
 
   fun ref unset(cap: U64): CapRights0^ =>
-    if Platform.freebsd() then
-      @__cap_rights_clear[Pointer[U64]](&_r0, cap, U64(0))
-    end
+    @__cap_rights_clear[Pointer[U64]](&_r0, cap, U64(0))
     this
 
   fun limit(fd: I32): Bool =>
     """
     Limits the fd to the encoded rights.
     """
-    if Platform.freebsd() then
-      @cap_rights_limit[I32](fd, &_r0) == 0
-    else
-      true
-    end
+    @cap_rights_limit[I32](fd, &_r0) == 0
 
   fun ref merge(that: CapRights0) =>
     """
     Merge the rights in that into this.
     """
-    if Platform.freebsd() then
-      @cap_rights_merge[Pointer[U64]](&_r0, &that._r0)
-    end
+    @cap_rights_merge[Pointer[U64]](&_r0, &that._r0)
 
   fun ref remove(that: CapRights0) =>
     """
     Remove the rights in that from this.
     """
-    if Platform.freebsd() then
-      @cap_rights_remove[Pointer[U64]](&_r0, &that._r0)
-    end
+    @cap_rights_remove[Pointer[U64]](&_r0, &that._r0)
 
   fun ref clear() =>
     """
     Clear all rights.
     """
-    if Platform.freebsd() then
-      @__cap_rights_init[Pointer[U64]](I32(0), &_r0, U64(0))
-    end
+    @__cap_rights_init[Pointer[U64]](I32(0), &_r0, U64(0))
 
   fun contains(that: CapRights0): Bool =>
     """
     Check that this is a superset of the rights in that.
     """
-    if Platform.freebsd() then
-      @cap_rights_contains[Bool](&_r0, &that._r0)
-    else
-      true
-    end
+    @cap_rights_contains[Bool](&_r0, &that._r0)

--- a/packages/capsicum/capsicum.pony
+++ b/packages/capsicum/capsicum.pony
@@ -9,11 +9,7 @@ primitive Cap
     descriptors or reading limited global system state. Access to global name
     spaces, such as file system or IPC name spaces, is prevented.
     """
-    if Platform.freebsd() then
-      @cap_enter[I32]() == 0
-    else
-      false
-    end
+    @cap_enter[I32]() == 0
 
   fun read(): U64 => _id(0, 1 << 0)
   fun write(): U64 => _id(0, 1 << 1)

--- a/packages/files/filedes.pony
+++ b/packages/files/filedes.pony
@@ -1,5 +1,5 @@
 use "time"
-use "capsicum"
+use "capsicum" if freebsd or linux
 
 primitive _FileDes
   """
@@ -57,7 +57,7 @@ primitive _FileDes
     """
     Set the Capsicum rights on the file descriptor.
     """
-    if Platform.freebsd() and (fd != -1) then
+    if (Platform.freebsd() or Platform.linux()) and (fd != -1) then
       let cap = CapRights.from(path.caps)
 
       if not writeable then

--- a/packages/stdlib/test.pony
+++ b/packages/stdlib/test.pony
@@ -11,7 +11,7 @@ All tests can be run by compiling and running packages/stdlib.
  """
 
 use "ponytest"
-use capsicum = "capsicum"
+use capsicum = "capsicum" if freebsd or linux
 use collections = "collections"
 use base64 = "encode/base64"
 use files = "files"


### PR DESCRIPTION
context: #292
Tested with Linux 3.19.0-capsicum+ and libcaprights-dev 0.1.0-1
(libcaprights only has shared libraries and didn't seem to work).

To get it to link:

```
use "capsicum"
use "lib:caprights"

...

   if Cap.enter() then
     ...
```