### PR TITLE
Fixes to compile on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,15 +45,15 @@ ifdef destdir
   endif
 endif
 
-destdir ?= /usr/local/lib/pony/$(tag)
 prefix ?= /usr/local
+destdir ?= $(prefix)/lib/pony/$(tag)
 
 LIB_EXT ?= a
 BUILD_FLAGS = -mcx16 -march=$(arch) -Werror -Wconversion \
   -Wno-sign-conversion -Wextra -Wall
 LINKER_FLAGS =
 ALL_CFLAGS = -std=gnu11 -DPONY_VERSION=\"$(tag)\"
-ALL_CXXFLAGS = -std=gnu++11
+ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
 
 PONY_BUILD_DIR   ?= build/$(config)
 PONY_SOURCE_DIR  ?= src
@@ -310,6 +310,11 @@ define CONFIGURE_COMPILER
   ifeq ($(suffix $(1)),.cc)
     compiler := $(CXX)
     flags := $(ALL_CXXFLAGS)
+  endif
+
+  ifeq ($(suffix $(1)),.c)
+    compiler := $(CC)
+    flags := $(ALL_CFLAGS)
   endif
 endef
 


### PR DESCRIPTION
There is three fixes on this commit:
1- Allow ponyc be installed at any location chosen by the "prefix" make parameter.
2- On ubuntu 14.04 with clan-3.6.2 I was getting error messages about -std=c++11 been used on "C" files.
3- Also on ubuntu 14.04 with clang-3.6.2 I was getting link time errors related to some "rtti" elements not found.

With this changes I was able to compile and install ponyc to a user folder (without need to install anything to /usr/loca/lib/ponyc).