### PR TITLE
Allow Pony to determine the platform's programming model in use conditions

### DIFF
--- a/packages/builtin/platform.pony
+++ b/packages/builtin/platform.pony
@@ -5,5 +5,9 @@ primitive Platform
   fun posix(): Bool => freebsd() or linux() or osx()
   fun windows(): Bool => compiler_intrinsic
 
+  fun lp64(): Bool => compiler_intrinsic
+  fun llp64(): Bool => compiler_intrinsic
+  fun ilp32(): Bool => compiler_intrinsic
+
   fun has_i128(): Bool => compiler_intrinsic
   fun debug(): Bool => compiler_intrinsic

--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -24,7 +24,7 @@
 #  define PLATFORM_IS_LINUX
 #elif defined(__FreeBSD__)
 #  define PLATFORM_IS_FREEBSD
-#elif defined(_WIN64)
+#elif defined(_WIN32)
 #  define PLATFORM_IS_WINDOWS
 #  if defined(_MSC_VER)
 #    define PLATFORM_IS_VISUAL_STUDIO
@@ -92,6 +92,17 @@
 
 #if defined(PLATFORM_IS_POSIX_BASED) || defined(__MINGW64__)
 #  define PLATFORM_IS_CLANG_OR_GCC
+#endif
+
+/** The platform's programming model.
+ *
+ */
+#if defined(__LP64__)
+#  define PLATFORM_IS_LP64
+#elif defined(_WIN64)
+#  define PLATFORM_IS_LLP64
+#else
+#  define PLATFORM_IS_ILP32
 #endif
 
 /** Data types.

--- a/src/libponyc/pkg/platformfuns.c
+++ b/src/libponyc/pkg/platformfuns.c
@@ -51,7 +51,37 @@ bool os_is_target(const char* attribute, bool release, bool* out_is_target)
 
   if(!strcmp(attribute, OS_POSIX_NAME))
   {
-#if defined PLATFORM_IS_POSIX_BASED
+#ifdef PLATFORM_IS_POSIX_BASED
+    *out_is_target = true;
+#else
+    *out_is_target = false;
+#endif
+    return true;
+  }
+
+  if(!strcmp(attribute, OS_LP64_NAME))
+  {
+#ifdef PLATFORM_IS_LP64
+    *out_is_target = true;
+#else
+    *out_is_target = false;
+#endif
+    return true;
+  }
+
+  if(!strcmp(attribute, OS_LLP64_NAME))
+  {
+#ifdef PLATFORM_IS_LLP64
+    *out_is_target = true;
+#else
+    *out_is_target = false;
+#endif
+    return true;
+  }
+
+  if(!strcmp(attribute, OS_ILP32_NAME))
+  {
+#ifdef PLATFORM_IS_ILP32
     *out_is_target = true;
 #else
     *out_is_target = false;

--- a/src/libponyc/pkg/platformfuns.h
+++ b/src/libponyc/pkg/platformfuns.h
@@ -11,6 +11,9 @@ PONY_EXTERN_C_BEGIN
 #define OS_MACOSX_NAME "osx"
 #define OS_WINDOWS_NAME "windows"
 #define OS_POSIX_NAME "posix"
+#define OS_LP64_NAME "lp64"
+#define OS_LLP64_NAME "llp64"
+#define OS_ILP32_NAME "ilp32"
 #define OS_HAS_I128_NAME "has_i128"
 #define OS_DEBUG_NAME "debug"
 


### PR DESCRIPTION
Hi!

Since Pony seems to target 32 and 64bits Linux, OSX, FreeBSD and Windows, I added checks for the different programming models on those platforms.
