### PR TITLE
Fix buffer overrun in add_exec_dir

### DIFF
--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -546,7 +546,7 @@ static bool add_safe(const char* path)
 // and add it to our search path
 static void add_exec_dir()
 {
-  char path[FILENAME_MAX];
+  char path[FILENAME_MAX + 1];
   bool success;
 
 #ifdef PLATFORM_IS_WINDOWS


### PR DESCRIPTION
If readlink returns FILENAME_MAX as the length of the copied string
then the following `path[r] = '\0'`, where r = FILENAME_MAX is a
1 byte out of bounds buffer overflow.

Fixed by allocating path to be FILENAME_MAX + 1 byte for the NULL
character.

(Bug found [using Coverity](https://scan4.coverity.com/reports.htm#v22790/p11538/fileInstanceId=4743130&defectInstanceId=1281844))