### PR TITLE
Fix possible buffer overrun in options find_match

### DIFF
--- a/src/libponyrt/options/options.c
+++ b/src/libponyrt/options/options.c
@@ -61,7 +61,7 @@ static const opt_arg_t* find_match(opt_state_t* s)
 
     if(!strncmp(match_name, s->opt_start, match_length))
     {
-      if(match_length == strlen(match_name))
+      if(match_length == strnlen(match_name, match_length))
       {
         // Exact match found. It is necessary to check for
         // the length of p->long_opt since there might be


### PR DESCRIPTION
If a match_type is not MATCH_LONG then the match_name
pointer points to p->short_opt which is a single char.

This is passed to strlen a few lines later. This will be
a buffer overrun if short_opt is not the null char.

The fix I'm doing here is to use strnlen and pass the
match_length, which is set to 1 for the case of
a short option.

Bug found using [coverity](https://scan.coverity.com/projects/doublec-ponyc).