### PR TITLE
Alternate fix to possible overrun in option parsing

### DIFF
--- a/src/libponyrt/options/options.c
+++ b/src/libponyrt/options/options.c
@@ -61,7 +61,7 @@ static const opt_arg_t* find_match(opt_state_t* s)
 
     if(!strncmp(match_name, s->opt_start, match_length))
     {
-      if(match_length == strlen(match_name))
+      if(s->match_type == MATCH_SHORT || match_length == strlen(match_name))
       {
         // Exact match found. It is necessary to check for
         // the length of p->long_opt since there might be


### PR DESCRIPTION
This is an alternate fix to the issue that was attempted
to be resolved in commit d1901df1. That fix had problems
with options that are substrings of other options. For
example, --antlr vs --antlrraw.

This fix explicitly checks for a SHORT option and does
not do the strlen test in that case. match_length will
always be 1 and the short option is length one so the
test will succeed.

See pull request #329 for details of the previous fix that was backed out. I'm looking out how the tests are done and I'll try adding some option tests if no one else gets to it.