### PR TITLE
Parse URL with omitted password

### DIFF
--- a/packages/net/http/test.pony
+++ b/packages/net/http/test.pony
@@ -42,3 +42,7 @@ class iso _TestURL is UnitTest
     h.expect_eq[String](url.path, "/wiki/Polymorphism_%28computer_science%29")
     h.expect_eq[String](url.query, "")
     h.expect_eq[String](url.fragment, "Parametric_polymorphism")
+
+    url = URL.build("http://user@host")
+    h.expect_eq[String](url.user, "user")
+    h.expect_eq[String](url.password, "")

--- a/packages/net/http/url.pony
+++ b/packages/net/http/url.pony
@@ -190,13 +190,10 @@ class val URL
     try
       let at = from.rfind("@", slash)
 
-      try
-        let colon = from.rfind(":", at)
-        user = from.substring(i, colon - 1)
-        password = from.substring(colon + 1, at - 1)
-      else
-        // Has no password.
-        user = from.substring(i, at - 1)
+      let user_end = try from.find(":", i).min(at) else at end
+      user = from.substring(i, user_end - 1)
+      if from.at(":", user_end) then
+        password = from.substring(user_end + 1, at - 1)
       end
 
       i = at + 1


### PR DESCRIPTION
Previous `URL.build()` implementation was looking for a colon to the left starting from **@**. When password part was omitted it found a colon after the scheme
```
http://user@host
    ^
```
thus resulting in empty username and `//user` as password.

--

Test case verifies only relevant URL fields as I believe the test should make it clear what's being tested. 