### PR TITLE
Fix history handling in Readline

### DIFF
--- a/packages/term/readline.pony
+++ b/packages/term/readline.pony
@@ -362,6 +362,7 @@ class Readline is ANSINotify
     """
     try
       if (_history.size() > 0) and (_history(_history.size() - 1) == line) then
+        _cur_line = _history.size()
         return
       end
     end


### PR DESCRIPTION
Hello.
This fixes a bug in Readline. When the same line is entered twice in a row, either from direct input or from the history, the position in the history isn't updated.
Example:
```
> A
(Press enter)
> B
(Press enter, then up)
> B
(Press enter, then up)
> A
```