### PR TITLE
Add support for Match.groups()

### DIFF
--- a/packages/regex/match.pony
+++ b/packages/regex/match.pony
@@ -81,7 +81,8 @@ class Match
 
   fun groups(): Array[String] iso^ =>
     """
-    Returns all of the captured subgroups.
+    Returns all of the captured subgroups.  Groups that failed to capture
+    anything will contain the empty string.
     """
     let res = recover Array[String] end
     var i: U64 = 1

--- a/packages/regex/regex.pony
+++ b/packages/regex/regex.pony
@@ -37,7 +37,7 @@ class Regex
     Return true on a successful match, false otherwise.
     """
     try
-      (let m, _) = _match(subject, 0, 0)
+      let m = _match(subject, 0, 0)
       @pcre2_match_data_free_8[None](m)
       true
     else
@@ -58,8 +58,8 @@ class Regex
 
     TODO: global match
     """
-    (let m, let size) = _match(subject, offset, U32(0))
-    Match._create(subject, m, size)
+    let m = _match(subject, offset, U32(0))
+    Match._create(subject, m)
 
   fun replace[A: (Seq[U8] iso & ByteSeq iso) = String iso](subject: ByteSeq,
     value: ByteSeq box, offset: U64 = 0, global: Bool = false): A^ ?
@@ -117,8 +117,8 @@ class Regex
     var off = consume offset
     try
       while off < subject.size() do
-        (let m', let size) = _match(subject, off, _PCRE2.not_empty())
-        let m = Match._create(subject, m', size)
+        let m' = _match(subject, off, _PCRE2.not_empty())
+        let m = Match._create(subject, m')
         let off' = m.start_pos() - 1
         out.push(subject.substring(off.i64(), off'.i64()))
         off = m.end_pos() + 1
@@ -152,7 +152,7 @@ class Regex
       _pattern = Pointer[_Pattern]
     end
 
-  fun _match(subject: ByteSeq box, offset: U64, options: U32): (Pointer[_Match], U64) ? =>
+  fun _match(subject: ByteSeq box, offset: U64, options: U32): Pointer[_Match]? =>
     """
     Match the subject and keep the capture results. Raises an error if there
     is no match.
@@ -176,8 +176,7 @@ class Regex
       @pcre2_match_data_free_8[None](m)
       error
     end
-
-    (m, rc.u64())
+    m
 
   fun _final() =>
     """

--- a/packages/regex/test.pony
+++ b/packages/regex/test.pony
@@ -6,6 +6,7 @@ actor Main is TestList
 
   fun tag tests(test: PonyTest) =>
     test(_TestApply)
+    test(_TestGroups)
     test(_TestEq)
     test(_TestSplit)
     test(_TestError)
@@ -22,6 +23,33 @@ class iso _TestApply is UnitTest
     h.expect_eq[String](m(0), "1234")
     h.expect_eq[U64](U64(2), m.start_pos())
     h.expect_eq[U64](U64(5), m.end_pos())
+    true
+
+class iso _TestGroups is UnitTest
+  """
+  Tests basic compilation and matching.
+  """
+  fun name(): String => "regex/Regex.groups"
+
+  fun apply(h: TestHelper): TestResult ? =>
+    let r = Regex.create("""(\d+)?\.(\d+)?""")
+    let m1 = r("123.456")
+    h.expect_eq[String](m1(0), "123.456")
+    h.expect_eq[String](m1(1), "123")
+    h.expect_eq[String](m1(2), "456")
+    h.expect_array_eq[String](m1.groups(), ["123", "456"])
+
+    let m2 = r("123.")
+    h.expect_eq[String](m2(0), "123.")
+    h.expect_eq[String](m2(1), "123")
+    h.expect_error(lambda()(m2 = m2)? => m2(2) end)
+    h.expect_array_eq[String](m2.groups(), ["123", ""])
+
+    let m3 = r(".456")
+    h.expect_eq[String](m3(0), ".456")
+    h.expect_error(lambda()(m3 = m3)? => m3(1) end)
+    h.expect_eq[String](m3(2), "456")
+    h.expect_array_eq[String](m3.groups(), ["", "456"])
     true
 
 class iso _TestEq is UnitTest


### PR DESCRIPTION
- API is similar to python's Match  https://docs.python.org/2/library/re.html#re.MatchObject.groups
- Fix the handling of group number counting