### PR TITLE
Use %zu to print size_t

### DIFF
--- a/src/libponyc/ast/treecheck.c
+++ b/src/libponyc/ast/treecheck.c
@@ -111,7 +111,7 @@ static bool check_children(ast_t* ast, check_state_t* state,
   if(state->child == NULL)
   {
     error_preamble(ast);
-    printf("found %ld child%s, expected more\n", state->child_index,
+    printf("found %zu child%s, expected more\n", state->child_index,
       (state->child_index == 1) ? "" : "ren");
     ast_error(ast, "Here");
     ast_print(ast);
@@ -119,7 +119,7 @@ static bool check_children(ast_t* ast, check_state_t* state,
   else
   {
     error_preamble(ast);
-    printf("child %ld has invalid id %d\n", state->child_index,
+    printf("child %zu has invalid id %d\n", state->child_index,
       ast_id(state->child));
     ast_error(ast, "Here");
     ast_print(ast);
@@ -141,7 +141,7 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state)
   if(state->child != NULL)
   {
     error_preamble(ast);
-    printf("child %ld (id %d, %s) unexpected\n", state->child_index,
+    printf("child %zu (id %d, %s) unexpected\n", state->child_index,
       ast_id(state->child), ast_get_print(state->child));
     ast_error(ast, "Here");
     ast_print(ast);

--- a/src/libponyc/pkg/ifdef.c
+++ b/src/libponyc/pkg/ifdef.c
@@ -352,7 +352,7 @@ static void check_config_count(buildflagset_t* config, ast_t* location)
     if(file == NULL)
       file = "";
 
-    printf("Processing %g configs at %s:%ld, this may take some time\n",
+    printf("Processing %g configs at %s:%zu, this may take some time\n",
       config_count, file, ast_line(location));
   }
 }

--- a/src/libponyc/reach/paint.c
+++ b/src/libponyc/reach/paint.c
@@ -145,7 +145,7 @@ void painter_print(painter_t* painter)
 {
   assert(painter != NULL);
 
-  printf("Painter typemaps are %lu bits\n",
+  printf("Painter typemaps are %zu bits\n",
     painter->typemap_size * sizeof(uint64_t) * 8);
 
   printf("Painter names:\n");

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -690,7 +690,7 @@ static void final(pony_ctx_t* ctx, pony_actor_t* self)
 
 static void dump_view(view_t* view)
 {
-  printf("%p: %lu (%s)\n",
+  printf("%p: %zu (%s)\n",
     view->actor, view->rc, view->blocked ? "blocked" : "unblocked");
 
   size_t i = HASHMAP_BEGIN;
@@ -698,7 +698,7 @@ static void dump_view(view_t* view)
 
   while((p = viewrefmap_next(&view->map, &i)) != NULL)
   {
-    printf("\t%p: %lu\n", p->view->actor, p->rc);
+    printf("\t%p: %zu\n", p->view->actor, p->rc);
   }
 }
 


### PR DESCRIPTION
Using z in format strings to print size_t was added in C99.  C++11
references the C99 standard, so this should be supported in C++11.