### PR TITLE
Accept box test function in TestHelper.assert_error()

### DIFF
--- a/packages/ponytest/helper.pony
+++ b/packages/ponytest/helper.pony
@@ -150,7 +150,7 @@ actor TestHelper
     log("Expect false passed. " + msg, true)
     true
 
-  fun tag assert_error(test: ITest, msg: String = "") ? =>
+  fun tag assert_error(test: ITest box, msg: String = "") ? =>
     """
     Assert that the given test function throws an error when run.
     """


### PR DESCRIPTION
This matches `expect_error()` declaration. Having parameter `test` as
box allows simpler lambda expression 

``` pony
lambda() ? => error end
```

instead of

``` pony
lambda ref() ? => error end
```