### PR TITLE
Return exact length substring

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -436,7 +436,7 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     nothing is in the range.
     """
     let start = offset_to_index(from)
-    let finish = offset_to_index(to).min(_size)
+    let finish = offset_to_index(to).min(_size - 1)
 
     if (start < _size) and (start <= finish) then
       let len = (finish - start) + 1

--- a/packages/stdlib/test.pony
+++ b/packages/stdlib/test.pony
@@ -49,6 +49,7 @@ actor Main is TestList
     test(_TestStringRstrip)
     test(_TestStringStrip)
     test(_TestStringRemove)
+    test(_TestStringSubstring)
     test(_TestStringReplace)
     test(_TestStringSplit)
     test(_TestStringJoin)
@@ -339,6 +340,17 @@ class iso _TestStringRemove is UnitTest
     h.expect_eq[String](consume s2, "barbar")
     h.expect_eq[String](consume s3, "foobar!")
     h.expect_eq[String](consume s4, "f-o-o-b-a-r!")
+
+    true
+
+class iso _TestStringSubstring is UnitTest
+  """
+  Test copying range of characters.
+  """
+  fun name(): String => "builtin/String.substring"
+
+  fun apply(h: TestHelper): TestResult =>
+    h.expect_eq[String]("3456", "0123456".substring(3, 99))
 
     true
 


### PR DESCRIPTION
When `String.substring()`'s `to` parameter exceeded maximum index, a
result was 1 byte longer than it should.