### PR TITLE
Fix File.set_length return value in success.

### DIFF
--- a/packages/files/file.pony
+++ b/packages/files/file.pony
@@ -407,8 +407,9 @@ class File
         _seek(0, 2)
       end
       success
+    else
+      false
     end
-    false
 
   fun info(): FileInfo ? =>
     """


### PR DESCRIPTION
Currently, `File.set_length` will always return `false`, even in success.

This PR fixes the control flow to return the correct boolean value.