### PR TITLE
String half-open range

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -648,33 +648,36 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     _set(_size, 0)
     this
 
-  fun cut(from: ISize, to: ISize = -1): String iso^ =>
+  fun cut(from: ISize, to: ISize = ISize.max_value()): String iso^ =>
     """
-    Returns a version of the string with the given range deleted. The range is
-    inclusive.
+    Returns a version of the string with the given range deleted.
+    Index range [`from` .. `to`) is half-open.
     """
     var s = clone()
     s.cut_in_place(from, to)
     s
 
-  fun ref cut_in_place(from: ISize, to: ISize = -1): String ref^ =>
+  fun ref cut_in_place(from: ISize, to: ISize = ISize.max_value()): String ref^
+  =>
     """
     Cuts the given range out of the string.
+    Index range [`from` .. `to`) is half-open.
     """
     let start = offset_to_index(from)
     let finish = offset_to_index(to).min(_size)
 
-    if (start < _size) and (start <= finish) and (finish < _size) then
-      let len = _size - ((finish - start) + 1)
-      var j = finish + 1
+    if (start < _size) and (start < finish) and (finish <= _size) then
+      let fragment_len = finish - start
+      let new_size = _size - fragment_len
+      var i = start
 
-      while j < _size do
-        _set(start + (j - (finish + 1)), _ptr._apply(j))
-        j = j + 1
+      while i < new_size do
+        _set(i, _ptr._apply(i + fragment_len))
+        i = i + 1
       end
 
-      _size = len
-      _set(len, 0)
+      _size = _size - fragment_len
+      _set(_size, 0)
     end
     this
 
@@ -689,7 +692,7 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     try
       while true do
         i = find(s, i)
-        cut_in_place(i, (i + s.size().isize()) - 1)
+        cut_in_place(i, i + s.size().isize())
         n = n + 1
       end
     end
@@ -702,7 +705,7 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     Replace up to n occurrences of `from` in `this` with `to`. If n is 0, all
     occurrences will be replaced.
     """
-    let from_len = from.size().isize() - 1
+    let from_len = from.size().isize()
     let to_len = to.size().isize()
     var offset = ISize(0)
     var occur = USize(0)

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -136,20 +136,20 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     """
     _size
 
-  fun codepoints(from: ISize = 0, to: ISize = -1): USize =>
+  fun codepoints(from: ISize = 0, to: ISize = ISize.max_value()): USize =>
     """
     Returns the number of unicode code points in the string between the two
-    offsets. From and to are inclusive.
+    offsets. Index range [`from` .. `to`) is half-open.
     """
     if _size == 0 then
       return 0
     end
 
     var i = offset_to_index(from)
-    var j = offset_to_index(to).min(_size - 1)
+    var j = offset_to_index(to).min(_size)
     var n = USize(0)
 
-    while i <= j do
+    while i < j do
       if (_ptr._apply(i) and 0xC0) != 0x80 then
         n = n + 1
       end

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -430,16 +430,16 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     end
     this
 
-  fun substring(from: ISize, to: ISize = -1): String iso^ =>
+  fun substring(from: ISize, to: ISize = ISize.max_value()): String iso^ =>
     """
-    Returns a substring. From and to are inclusive. Returns an empty string if
-    nothing is in the range.
+    Returns a substring. Index range [`from` .. `to`) is half-open.
+    Returns an empty string if nothing is in the range.
     """
     let start = offset_to_index(from)
-    let finish = offset_to_index(to).min(_size - 1)
+    let finish = offset_to_index(to).min(_size)
 
-    if (start < _size) and (start <= finish) then
-      let len = (finish - start) + 1
+    if (start < _size) and (start < finish) then
+      let len = finish - start
       var str = recover String(len) end
       _ptr._offset(start)._copy_to(str._ptr, len)
       str._size = len

--- a/packages/net/http/url.pony
+++ b/packages/net/http/url.pony
@@ -164,7 +164,7 @@ class val URL
         end
 
         // Otherwise, we have a scheme. Set it and return the offset.
-        scheme = recover from.substring(0, i.isize() - 1).lower_in_place() end
+        scheme = recover from.substring(0, i.isize()).lower_in_place() end
         return i.isize() + 1
       else
         // Anything else is not a scheme.
@@ -191,9 +191,9 @@ class val URL
       let at = from.rfind("@", slash)
 
       let user_end = try from.find(":", i).min(at) else at end
-      user = from.substring(i, user_end - 1)
+      user = from.substring(i, user_end)
       if from.at(":", user_end) then
-        password = from.substring(user_end + 1, at - 1)
+        password = from.substring(user_end + 1, at)
       end
 
       i = at + 1
@@ -203,14 +203,14 @@ class val URL
       let colon = from.find(":", i)
 
       if colon < slash then
-        host = from.substring(i, colon - 1)
-        service = from.substring(colon + 1, slash - 1)
+        host = from.substring(i, colon)
+        service = from.substring(colon + 1, slash)
       else
         error
       end
     else
       // Has no port
-      host = from.substring(i, slash - 1)
+      host = from.substring(i, slash)
 
       service = match scheme
       | "http" => "80"
@@ -228,25 +228,25 @@ class val URL
     """
     try
       let q = from.find("?", offset)
-      path = from.substring(offset, q - 1)
+      path = from.substring(offset, q)
 
       try
         let h = from.find("#", q + 1)
-        query = from.substring(q + 1, h - 1)
-        fragment = from.substring(h + 1, -1)
+        query = from.substring(q + 1, h)
+        fragment = from.substring(h + 1)
       else
         // Has no fragment
-        query = from.substring(q + 1, -1)
+        query = from.substring(q + 1)
       end
     else
       // Has no query.
       try
         let h = from.find("#", offset + 1)
-        path = from.substring(offset, h - 1)
-        fragment = from.substring(h + 1, -1)
+        path = from.substring(offset, h)
+        fragment = from.substring(h + 1)
       else
         // Has no fragment
-        path = from.substring(offset, -1)
+        path = from.substring(offset)
       end
     end
 

--- a/packages/regex/regex.pony
+++ b/packages/regex/regex.pony
@@ -118,12 +118,12 @@ class Regex
       while off < subject.size() do
         let m' = _match(subject, off, _PCRE2.not_empty())
         let m = Match._create(subject, m')
-        let off' = m.start_pos() - 1
+        let off' = m.start_pos()
         out.push(subject.substring(off.isize(), off'.isize()))
         off = m.end_pos() + 1
       end
     else
-      out.push(subject.substring(off.isize(), -1))
+      out.push(subject.substring(off.isize()))
     end
 
     out

--- a/packages/stdlib/test.pony
+++ b/packages/stdlib/test.pony
@@ -50,6 +50,7 @@ actor Main is TestList
     test(_TestStringStrip)
     test(_TestStringRemove)
     test(_TestStringSubstring)
+    test(_TestStringCut)
     test(_TestStringReplace)
     test(_TestStringSplit)
     test(_TestStringJoin)
@@ -354,6 +355,19 @@ class iso _TestStringSubstring is UnitTest
     h.expect_eq[String]("3456", "0123456".substring(3, 7))
     h.expect_eq[String]("3456", "0123456".substring(3))
     h.expect_eq[String]("345", "0123456".substring(3, -1))
+
+    true
+
+class iso _TestStringCut is UnitTest
+  """
+  Test cutting part of a string
+  """
+  fun name(): String => "builtin/String.cut"
+
+  fun apply(h: TestHelper): TestResult =>
+    h.expect_eq[String]("01236", "0123456".cut(4, 6))
+    h.expect_eq[String]("0123", "0123456".cut(4, 7))
+    h.expect_eq[String]("0123", "0123456".cut(4))
 
     true
 

--- a/packages/stdlib/test.pony
+++ b/packages/stdlib/test.pony
@@ -350,6 +350,11 @@ class iso _TestStringSubstring is UnitTest
   fun apply(h: TestHelper): TestResult =>
     h.expect_eq[String]("3456", "0123456".substring(3, 99))
 
+    h.expect_eq[String]("345", "0123456".substring(3, 6))
+    h.expect_eq[String]("3456", "0123456".substring(3, 7))
+    h.expect_eq[String]("3456", "0123456".substring(3))
+    h.expect_eq[String]("345", "0123456".substring(3, -1))
+
     true
 
 class iso _TestSpecialValuesF32 is UnitTest


### PR DESCRIPTION
Initial inclusive range implementation was inspired by languages like R,
Julia, Lua. It turned out all these languages are one-indexed whereas
Pony indexes start from 0. After the discussion (see #359) agreement has
been made to change the range to half-open.