### PR TITLE
Clean up uses of String.substring and codepoints methods after #417.

### DIFF
--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -166,7 +166,7 @@ class Directory
         repeat
           let element = try
             offset = target.find(Path.sep(), offset) + 1
-            target.substring(0, offset - 2)
+            target.substring(0, offset - 1)
           else
             offset = -1
             target

--- a/packages/files/filepath.pony
+++ b/packages/files/filepath.pony
@@ -90,7 +90,7 @@ class val FilePath
     repeat
       let element = try
         offset = path.find(Path.sep(), offset) + 1
-        path.substring(0, offset - 2)
+        path.substring(0, offset - 1)
       else
         offset = -1
         path

--- a/packages/files/path.pony
+++ b/packages/files/path.pony
@@ -57,7 +57,7 @@ primitive Path
       try
         if is_sep(path(-1)) then
           if is_sep(next_path(0)) then
-            return clean(path + next_path.substring(1, -1))
+            return clean(path + next_path.substring(1))
           else
             return clean(path + next_path)
           end
@@ -286,10 +286,10 @@ primitive Path
 
       result.append("..")
       result.append(sep())
-      result.append(target_clean.substring(target_0, -1))
+      result.append(target_clean.substring(target_0))
       result
     else
-      target_clean.substring(target_0, -1)
+      target_clean.substring(target_0)
     end
 
   fun base(path: String): String =>
@@ -299,7 +299,7 @@ primitive Path
     """
     try
       var i = path.rfind(sep())
-      path.substring(i + 1, -1)
+      path.substring(i + 1)
     else
       path
     end
@@ -311,7 +311,7 @@ primitive Path
     """
     try
       var i = path.rfind(sep())
-      clean(path.substring(0, i - 1))
+      clean(path.substring(0, i))
     else
       path
     end
@@ -331,7 +331,7 @@ primitive Path
       end
 
       if i >= j then
-        return path.substring(i + 1, -1)
+        return path.substring(i + 1)
       end
     end
     ""
@@ -353,7 +353,7 @@ primitive Path
       end
 
       if _drive_letter(path, offset) then
-        return path.substring(0, offset + 1)
+        return path.substring(0, offset + 2)
       end
 
       try
@@ -361,7 +361,7 @@ primitive Path
           is_sep(path.at_offset(offset)) and
           is_sep(path.at_offset(offset + 1))
         then
-          return _network_share(path, offset + 2)
+          return _network_share(path, offset + 3)
         end
       end
     end
@@ -390,7 +390,7 @@ primitive Path
 
       try
         next = path.find("\\", next) - 1
-        path.substring(0, next)
+        path.substring(0, next + 1)
       else
         path
       end
@@ -481,11 +481,11 @@ primitive Path
     try
       while true do
         var next = path.find(list_sep(), offset)
-        array.push(clean(path.substring(offset, next - 1)))
+        array.push(clean(path.substring(offset, next)))
         offset = next + 1
       end
     else
-      array.push(clean(path.substring(offset, -1)))
+      array.push(clean(path.substring(offset)))
     end
 
     array

--- a/packages/net/http/payloadbuilder.pony
+++ b/packages/net/http/payloadbuilder.pony
@@ -117,11 +117,11 @@ class _PayloadBuilder
 
       try
         let method_end = line.find(" ")
-        _payload.method = line.substring(0, method_end - 1)
+        _payload.method = line.substring(0, method_end)
 
         let url_end = line.find(" ", method_end + 1)
-        _payload.url = URL.valid(line.substring(method_end + 1, url_end - 1))
-        _payload.proto = line.substring(url_end + 1, -1)
+        _payload.url = URL.valid(line.substring(method_end + 1, url_end))
+        _payload.proto = line.substring(url_end + 1)
 
         _state = _PayloadHeaders
         parse(buffer)
@@ -139,11 +139,11 @@ class _PayloadBuilder
 
       try
         let proto_end = line.find(" ")
-        _payload.proto = line.substring(0, proto_end - 1)
+        _payload.proto = line.substring(0, proto_end)
         _payload.status = line.read_int[U16](proto_end + 1)._1
 
         let status_end = line.find(" ", proto_end + 1)
-        _payload.method = line.substring(status_end + 1, -1)
+        _payload.method = line.substring(status_end + 1)
 
         _state = _PayloadHeaders
         parse(buffer)
@@ -163,8 +163,8 @@ class _PayloadBuilder
         if line.size() > 0 then
           try
             let i = line.find(":")
-            let key = recover val line.substring(0, i - 1).strip() end
-            let value = recover val line.substring(i + 1, -1).strip() end
+            let key = recover val line.substring(0, i).strip() end
+            let value = recover val line.substring(i + 1).strip() end
             _payload(key) = value
 
             match key.lower()

--- a/packages/options/envvars.pony
+++ b/packages/options/envvars.pony
@@ -11,8 +11,8 @@ primitive EnvVars
     for kv in from.values() do
       try
         let delim = kv.find("=")
-        let k = kv.substring(0, delim - 1)
-        let v = kv.substring(delim + 1, -1)
+        let k = kv.substring(0, delim)
+        let v = kv.substring(delim + 1)
         map(consume k) = consume v
       else
         map(kv) = ""

--- a/packages/options/options.pony
+++ b/packages/options/options.pony
@@ -90,7 +90,7 @@ class Options is Iterator[(ParsedOption | ParseError | None)]
     Selects an option from the configuration depending on the current command
     line argument.
     """
-    let name: String box = candidate.substring(start, finish)
+    let name: String box = candidate.substring(start, finish + 1)
     var matches = Array[_Option]
     var selected: (_Option | None) = None
 
@@ -105,7 +105,7 @@ class Options is Iterator[(ParsedOption | ParseError | None)]
     | (let opt: _Option, 1) => _strip(opt, candidate, offset, finish) ; opt
     | (let opt: _Option, _) => _ErrorPrinter._ambiguous(matches)
     else
-      _ErrorPrinter._unrecognised(candidate.substring(0, finish))
+      _ErrorPrinter._unrecognised(candidate.substring(0, finish + 1))
     end
 
   fun ref _skip(): Bool =>

--- a/packages/term/readline.pony
+++ b/packages/term/readline.pony
@@ -348,7 +348,7 @@ class Readline is ANSINotify
       var pos = _cur_prompt.codepoints()
 
       if _cur_pos > 0 then
-        pos = pos + _edit.codepoints(0, _cur_pos - 1)
+        pos = pos + _edit.codepoints(0, _cur_pos)
       end
 
       out.append("\r")


### PR DESCRIPTION
PR #417 left some uses of `String.substring` and `String.codepoints` unchanged, where they should have been changed to match the changed behavior of the second argument.

This was probably the cause of #427.

This PR fixes the remaining uses of these methods.  I did a full search for these methods on all files in the repo, and compared to the list of those changed in #417.

@andymcn [Here's one spot I wasn't sure about in the JSON package](https://github.com/CausalityLtd/ponyc/blob/873323591465b29d4de5a27d923ec02d9a078f73/packages/json/doc.pony#L423) - I don't understand how this invocation was supposed to work, since `to` will usually be less than `from` here.  I thought I would leave that for you to deal with since you wrote that snippet and I don't understand what's going on there.