### PR TITLE
Compare substrings when negative offsets given

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -902,7 +902,7 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     """
     var i = n
     var j: USize = offset_to_index(offset)
-    var k: USize = offset_to_index(that_offset)
+    var k: USize = that.offset_to_index(that_offset)
 
     if (j + n) > _size then
       return Less

--- a/packages/stdlib/test.pony
+++ b/packages/stdlib/test.pony
@@ -514,6 +514,8 @@ class iso _TestStringCompare is UnitTest
     test(h, Equal, "AB", "ab", 2 where ignore_case = true)
     test(h, Equal, "AB", "AB", 2 where ignore_case = true)
 
+    test(h, Equal, "foobar", "bar", 2, -2, -2)
+
     true
 
   fun test(h: TestHelper, expect: Compare, receiver: String box,


### PR DESCRIPTION
Negative offset is relative to string and depends on its size. This
dictates that offset has to be translated to index in the context of
corresponding string.