### PR TITLE
Increase ProductVersion Length

### DIFF
--- a/src/libponyc/platform/vcvars.c
+++ b/src/libponyc/platform/vcvars.c
@@ -13,7 +13,7 @@
 #define REG_VC_TOOLS_PATH \
   TEXT("SOFTWARE\\Microsoft\\DevDiv\\VCForPython\\9.0")
 
-#define MAX_VER_LEN 10
+#define MAX_VER_LEN 11
 
 typedef struct search_t search_t;
 typedef void(*query_callback_fn)(HKEY key, char* name, search_t* p);

--- a/src/libponyc/platform/vcvars.c
+++ b/src/libponyc/platform/vcvars.c
@@ -13,7 +13,7 @@
 #define REG_VC_TOOLS_PATH \
   TEXT("SOFTWARE\\Microsoft\\DevDiv\\VCForPython\\9.0")
 
-#define MAX_VER_LEN 11
+#define MAX_VER_LEN 20
 
 typedef struct search_t search_t;
 typedef void(*query_callback_fn)(HKEY key, char* name, search_t* p);


### PR DESCRIPTION
Windows 10 has a longer ProductVersion size than the current code permits.