### PR TITLE
Better error message for missing ref

### DIFF
--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -466,7 +466,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
 
         if(iso_id == TK_BOX || iso_id == TK_VAL || iso_id == TK_TAG)
         {
-          ast_error(ast, "cannot write to a field in a %s function. If you are trying to use references in a function use ref",
+          ast_error(ast, "cannot write to a field in a %s function. If you are trying to change state in a function use fun ref",
             lexer_print(iso_id));
           ast_free_unattached(a_type);
           return false;

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -466,7 +466,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
 
         if(iso_id == TK_BOX || iso_id == TK_VAL || iso_id == TK_TAG)
         {
-          ast_error(ast, "cannot write to a field in a %s function",
+          ast_error(ast, "cannot write to a field in a %s function. If you are trying to use references in a function use ref",
             lexer_print(iso_id));
           ast_free_unattached(a_type);
           return false;


### PR DESCRIPTION
I am just playing with the language at the moment and I was surprised by the  error message I got (until I wen to read the docs) 
I thought a better error message might help. Perhaps the message could be even more descriptive or specific? 