### PR TITLE
Options tests and fixes

### DIFF
--- a/packages/options/options.pony
+++ b/packages/options/options.pony
@@ -1,8 +1,5 @@
 """
 ## PonyOptions package
-Implementing GNU extensions to the POSIX recommendations for command-line
-options.
-See: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
 """
 
 primitive StringArgument

--- a/packages/options/options.pony
+++ b/packages/options/options.pony
@@ -1,5 +1,8 @@
 """
 ## PonyOptions package
+Implementing GNU extensions to the POSIX recommendations for command-line
+options.
+See: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
 """
 
 primitive StringArgument
@@ -90,8 +93,8 @@ class Options is Iterator[(ParsedOption | ParseError | None)]
     Selects an option from the configuration depending on the current command
     line argument.
     """
-    let name: String box = candidate.substring(start, finish + 1)
-    var matches = Array[_Option]
+    let name: String box = candidate.substring(start, finish)
+    let matches = Array[_Option]
     var selected: (_Option | None) = None
 
     for opt in _configuration.values() do
@@ -186,14 +189,13 @@ class Options is Iterator[(ParsedOption | ParseError | None)]
             (0, 0) // unreachable
           end
 
-        let finish: ISize =
+        let last = candidate.size().isize()
+        (let finish: ISize, let combined: Bool) =
           try
-            candidate.find("=") - 1
+            (candidate.find("="), true)
           else
-            if start == 1 then start else -1 end
+            (if start == 1 then start+1 else last end, false)
           end
-
-        let combined = (finish != start) and (finish != -1)
 
         match _select(candidate, start, offset, finish)
         | let err: ParseError => _error = true ; _index = _index + 1 ; err

--- a/packages/options/test.pony
+++ b/packages/options/test.pony
@@ -9,84 +9,143 @@ actor Main is TestList
     test(_TestShortOptions)
     test(_TestCombineShortOptions)
     test(_TestCombineShortArg)
-    test(_TestArgEquals)
-    test(_TestArgSpace)
     test(_TestArgLeadingDash)
+
+primitive TestOptions
+  fun from(renv: Env val, args: Array[String] val): Options =>
+    let env = recover val Env.create(renv.root, renv.input, renv.out, renv.err, args, None) end
+    Options(env)
 
 class iso _TestLongOptions is UnitTest
   """
-  Long options start with two leading dashes.
+  Long options start with two leading dashes, and can be lone, have a following arg, or combined arg with =.
   """
-  //let _env: Env
-
   fun name(): String => "options/Options.longOptions"
 
   fun apply(h: TestHelper): TestResult =>
+    let options = TestOptions.from(h.env, recover ["--none", "--i64", "12345", "--f64=67.890"] end)
+    var none: Bool = false
+    var i64: I64 = -1
+    var f64: F64 = -1
+    options
+      .add("none", "n", None, Optional)
+      .add("i64", "i", I64Argument, Optional)
+      .add("f64", "f", F64Argument, Optional)
+    for option in options do
+      match option
+      | ("none", var arg: None) => none = true
+      | ("i64", var arg: I64) => i64 = arg
+      | ("f64", var arg: F64) => f64 = arg
+      end
+    end
+
+    h.expect_eq[Bool](true, none)
+    h.expect_eq[I64](12345, i64)
+    h.expect_eq[F64](67.890, f64)
     true
 
 class iso _TestShortOptions is UnitTest
   """
-  Short options start with a single leading dash.
+  Short options start with a single leading dash, and can be lone, have a following arg, or combined arg with =.
   """
-  //let _env: Env
-
   fun name(): String => "options/Options.shortOptions"
 
   fun apply(h: TestHelper): TestResult =>
+    let options = TestOptions.from(h.env, recover val ["-n", "-i", "12345", "-f67.890"] end)
+    var none: Bool = false
+    var i64: I64 = -1
+    var f64: F64 = -1
+    options
+      .add("none", "n", None, Optional)
+      .add("i64", "i", I64Argument, Optional)
+      .add("f64", "f", F64Argument, Optional)
+    for option in options do
+      match option
+      | ("none", var arg: None) => none = true
+      | ("i64", var arg: I64) => i64 = arg
+      | ("f64", var arg: F64) => f64 = arg
+      end
+    end
+
+    h.expect_eq[Bool](true, none)
+    h.expect_eq[I64](12345, i64)
+    h.expect_eq[F64](67.890, f64)
     true
 
 class iso _TestCombineShortOptions is UnitTest
   """
-  Short options can be combined to one string with a single leading dash. 
+  Short options can be combined into one string with a single leading dash.
   """
-  //let _env: Env
-
   fun name(): String => "options/Options.combineShort"
 
   fun apply(h: TestHelper): TestResult =>
+    let options = TestOptions.from(h.env, recover val ["-ab"] end)
+    var aaa: Bool = false
+    var bbb: Bool = false
+    options
+      .add("aaa", "a", None, Optional)
+      .add("bbb", "b", None, Optional)
+    for option in options do
+      match option
+      | ("aaa", _) => aaa = true
+      | ("bbb", _) => bbb = true
+      end
+    end
+
+    h.expect_eq[Bool](true, aaa)
+    h.expect_eq[Bool](true, bbb)
     true
 
 class iso _TestCombineShortArg is UnitTest
   """
   Short options can be combined up to the first option that takes an argument.
   """
-  //let _env: Env
-
   fun name(): String => "options/Options.combineShortArg"
 
   fun apply(h: TestHelper): TestResult =>
-    true
+    let options = TestOptions.from(h.env, recover val ["-ab99", "-ac", "99"] end)
+    var aaa: Bool = false
+    var bbb: I64 = -1
+    var ccc: I64 = -1
+    options
+      .add("aaa", "a", None, Optional)
+      .add("bbb", "b", I64Argument, Optional)
+      .add("ccc", "c", I64Argument, Optional)
+    for option in options do
+      match option
+      | ("aaa", _) => aaa = true
+      | ("bbb", var arg: I64) => bbb = arg
+      | ("ccc", var arg: I64) => ccc = arg
+      end
+    end
 
-class iso _TestArgEquals is UnitTest
-  """
-  Arguments can be distinguished from long and short options using '='.
-  """
-  //let _env: Env
-
-  fun name(): String => "options/Options.testArgEquals"
-
-  fun apply(h: TestHelper): TestResult =>
-    true
-
-class iso _TestArgSpace is UnitTest
-  """
-  Arguments can be distinguished from long and short options using space.
-  """
-  //let _env: Env
-
-  fun name(): String => "options/Options.testArgSpace"
-
-  fun apply(h: TestHelper): TestResult =>
+    h.expect_eq[Bool](true, aaa)
+    h.expect_eq[I64](99, bbb)
+    h.expect_eq[I64](99, ccc)
     true
 
 class iso _TestArgLeadingDash is UnitTest
   """
-  Arguments can only start with a leading dash, if they are seperated from
+  Arguments can only start with a leading dash if they are separated from
   the option using '=', otherwise they will be interpreted as named options.
   """
-  //let _env: Env
-
   fun name(): String => "options/Options.testArgLeadingDash"
 
   fun apply(h: TestHelper): TestResult =>
+    let options = TestOptions.from(h.env, recover val ["--aaa", "-2", "--bbb=-2"] end)
+    var aaa: I64 = -1
+    var bbb: I64 = -1
+    options
+      .add("aaa", "c", I64Argument, Optional)
+      .add("bbb", "b", I64Argument, Optional)
+      .add("ttt", "2", None, Optional)  // to ignore the -2
+    for option in options do
+      match option
+      | ("aaa", var arg: I64) => aaa = arg
+      | ("bbb", var arg: I64) => bbb = arg
+      end
+    end
+
+    h.expect_eq[I64](-1, aaa)
+    h.expect_eq[I64](-2, bbb)
     true


### PR DESCRIPTION
Fleshed out the unit tests for Options, combining a couple.
Fixed discovered broken Options parsing off-by-one errors. These may have been introduced by the changes to use half-open range for String, and missed due to lack of tests.