### PR TITLE
use darwin system AR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ else
   ifeq ($(UNAME_S),Darwin)
     OSTYPE = osx
     lto := yes
+    AR := /usr/bin/ar
   endif
 
   ifeq ($(UNAME_S),FreeBSD)

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ LIB_EXT ?= a
 BUILD_FLAGS = -march=$(arch) -Werror -Wconversion \
   -Wno-sign-conversion -Wextra -Wall
 LINKER_FLAGS = -march=$(arch)
-AR_FLAGS =
+AR_FLAGS = -rcs
 ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_VERSION=\"$(tag)\" -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\"
 ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
@@ -428,7 +428,7 @@ $(foreach d,$($(1).depends),$(eval depends += $($(d))/$(d).$(LIB_EXT)))
 ifneq ($(filter $(1),$(libraries)),)
 $($(1))/$(1).$(LIB_EXT): $(depends) $(ofiles)
 	@echo 'Linking $(1)'
-	$(SILENT)$(AR) -rcs $$@ $(ofiles) $(AR_FLAGS)
+	$(SILENT)$(AR) $(AR_FLAGS) $$@ $(ofiles)
 $(1): $($(1))/$(1).$(LIB_EXT)
 else
 $($(1))/$(1): $(depends) $(ofiles)


### PR DESCRIPTION
override macports /opt/local/bin/ar, causing all kind of assertions in config=release with lto

also let AR_FLAGS be overridden. i.e. AR=llvm-ar needs rs, not -rcs when
archiving byte-compiled code for lto