### PR TITLE
use darwin system linker

### DIFF
--- a/packages/net/ssl/sslinit.pony
+++ b/packages/net/ssl/sslinit.pony
@@ -1,4 +1,5 @@
 use "path:/usr/local/opt/libressl/lib" if osx
+use "path:/opt/local/lib" if osx
 use "lib:ssl" if not windows
 use "lib:crypto" if not windows
 use "lib:libssl-32" if windows

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -238,15 +238,16 @@ static bool link_exe(compile_t* c, ast_t* program,
     strlen(lib_args);
   char* ld_cmd = (char*)pool_alloc_size(ld_len);
 
+  // Avoid incorrect ld, eg from macports.
   snprintf(ld_cmd, ld_len,
-    "ld -execute -no_pie -dead_strip -arch %.*s -macosx_version_min 10.8 "
-    "-o %s %s %s -lponyrt -lSystem",
+    "/usr/bin/ld -execute -no_pie -dead_strip -arch %.*s "
+    "-macosx_version_min 10.8 -o %s %s %s -lponyrt -lSystem",
     (int)arch_len, c->opt->triple, file_exe, file_o, lib_args
     );
 
   if(system(ld_cmd) != 0)
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: %s", ld_cmd);
     pool_free_size(ld_len, ld_cmd);
     return false;
   }
@@ -303,7 +304,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   if(system(ld_cmd) != 0)
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: %s", ld_cmd);
     pool_free_size(ld_len, ld_cmd);
     return false;
   }
@@ -314,7 +315,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   if(!vcvars_get(&vcvars))
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: no vcvars");
     return false;
   }
 
@@ -341,7 +342,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   if(system(ld_cmd) == -1)
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: %s", ld_cmd);
     pool_free_size(ld_len, ld_cmd);
     return false;
   }

--- a/src/libponyc/codegen/genlib.c
+++ b/src/libponyc/codegen/genlib.c
@@ -160,11 +160,15 @@ static bool link_lib(compile_t* c, const char* file_o)
   size_t len = 32 + strlen(file_lib) + strlen(file_o);
   char* cmd = (char*)pool_alloc_size(len);
 
+#if defined(PLATFORM_IS_MACOSX)
+  snprintf(cmd, len, "/usr/bin/ar -rcs %s %s", file_lib, file_o);
+#else
   snprintf(cmd, len, "ar -rcs %s %s", file_lib, file_o);
+#endif
 
   if(system(cmd) != 0)
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: %s", cmd);
     pool_free_size(len, cmd);
     return false;
   }
@@ -179,7 +183,7 @@ static bool link_lib(compile_t* c, const char* file_o)
 
   if(!vcvars_get(&vcvars))
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: no vcvars");
     return false;
   }
 
@@ -191,7 +195,7 @@ static bool link_lib(compile_t* c, const char* file_o)
 
   if(system(cmd) == -1)
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: %s", cmd);
     pool_free_size(len, cmd);
     return false;
   }


### PR DESCRIPTION
and not the macports `/opt/local/bin/ld` variant
to find the 3.6 llvm libdir for the right -fLTO lib.

Fixes #467 and issues with fellow macports folks with
config=release.
See e.g. https://github.com/CausalityLtd/ponyc/issues/456#issuecomment-169082678
who had the same problem as me.