### PR TITLE
force install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,34 +470,34 @@ endif
 endef
 
 define EXPAND_INSTALL
-install: libponyc libponyrt ponyc
+install: libponyc libponyrt ponyc FORCE
 	@mkdir -p $(destdir)/bin
 	@mkdir -p $(destdir)/lib
 	@mkdir -p $(destdir)/include
-	@cp $(PONY_BUILD_DIR)/libponyrt.a $(destdir)/lib
-	@cp $(PONY_BUILD_DIR)/libponyc.a $(destdir)/lib
-	@cp $(PONY_BUILD_DIR)/ponyc $(destdir)/bin
-	@cp src/libponyrt/pony.h $(destdir)/include
-	@cp -r packages $(destdir)/
+	$(SILENT)cp $(PONY_BUILD_DIR)/libponyrt.a $(destdir)/lib
+	$(SILENT)cp $(PONY_BUILD_DIR)/libponyc.a $(destdir)/lib
+	$(SILENT)cp $(PONY_BUILD_DIR)/ponyc $(destdir)/bin
+	$(SILENT)cp src/libponyrt/pony.h $(destdir)/include
+	$(SILENT)cp -r packages $(destdir)/
 ifeq ($$(symlink),yes)
 	@mkdir -p $(prefix)/bin
 	@mkdir -p $(prefix)/lib
 	@mkdir -p $(prefix)/include
-	@ln -sf $(destdir)/bin/ponyc $(prefix)/bin/ponyc
-	@ln -sf $(destdir)/lib/libponyrt.a $(prefix)/lib/libponyrt.a
-	@ln -sf $(destdir)/lib/libponyc.a $(prefix)/lib/libponyc.a
-	@ln -sf $(destdir)/include/pony.h $(prefix)/include/pony.h
+	$(SILENT)ln -sf $(destdir)/bin/ponyc $(prefix)/bin/ponyc
+	$(SILENT)ln -sf $(destdir)/lib/libponyrt.a $(prefix)/lib/libponyrt.a
+	$(SILENT)ln -sf $(destdir)/lib/libponyc.a $(prefix)/lib/libponyc.a
+	$(SILENT)ln -sf $(destdir)/include/pony.h $(prefix)/include/pony.h
 endif
 endef
 
 $(eval $(call EXPAND_INSTALL))
 
 uninstall:
-	-@rm -rf $(destdir) 2>/dev/null ||:
-	-@rm $(prefix)/bin/ponyc 2>/dev/null ||:
-	-@rm $(prefix)/lib/libponyrt.a 2>/dev/null ||:
-	-@rm $(prefix)/lib/libponyc.a 2>/dev/null ||:
-	-@rm $(prefix)/include/pony.h 2>/dev/null ||:
+	-$(SILENT)rm -rf $(destdir) 2>/dev/null ||:
+	-$(SILENT)rm $(prefix)/bin/ponyc 2>/dev/null ||:
+	-$(SILENT)rm $(prefix)/lib/libponyrt.a 2>/dev/null ||:
+	-$(SILENT)rm $(prefix)/lib/libponyc.a 2>/dev/null ||:
+	-$(SILENT)rm $(prefix)/include/pony.h 2>/dev/null ||:
 
 test: all
 	@$(PONY_BUILD_DIR)/libponyc.tests
@@ -602,3 +602,13 @@ help:
 	@echo '  stats             Print Pony cloc statistics'
 	@echo '  clean             Delete all build files'
 	@echo
+
+.PHONY: FORCE
+
+ifeq ($(OS),Windows_NT)
+FORCE:
+	@cmd /c true
+else
+FORCE:
+	@sh -c true
+endif

--- a/packages/net/ssl/sslinit.pony
+++ b/packages/net/ssl/sslinit.pony
@@ -1,4 +1,5 @@
 use "path:/usr/local/opt/libressl/lib" if osx
+use "path:/opt/local/lib" if osx
 use "lib:ssl" if not windows
 use "lib:crypto" if not windows
 use "lib:libssl-32" if windows

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -238,15 +238,16 @@ static bool link_exe(compile_t* c, ast_t* program,
     strlen(lib_args);
   char* ld_cmd = (char*)pool_alloc_size(ld_len);
 
+  // Avoid incorrect ld, eg from macports.
   snprintf(ld_cmd, ld_len,
-    "ld -execute -no_pie -dead_strip -arch %.*s -macosx_version_min 10.8 "
-    "-o %s %s %s -lponyrt -lSystem",
+    "/usr/bin/ld -execute -no_pie -dead_strip -arch %.*s "
+    "-macosx_version_min 10.8 -o %s %s %s -lponyrt -lSystem",
     (int)arch_len, c->opt->triple, file_exe, file_o, lib_args
     );
 
   if(system(ld_cmd) != 0)
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: %s", ld_cmd);
     pool_free_size(ld_len, ld_cmd);
     return false;
   }
@@ -303,7 +304,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   if(system(ld_cmd) != 0)
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: %s", ld_cmd);
     pool_free_size(ld_len, ld_cmd);
     return false;
   }
@@ -314,7 +315,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   if(!vcvars_get(&vcvars))
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: no vcvars");
     return false;
   }
 
@@ -341,7 +342,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   if(system(ld_cmd) == -1)
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: %s", ld_cmd);
     pool_free_size(ld_len, ld_cmd);
     return false;
   }

--- a/src/libponyc/codegen/genlib.c
+++ b/src/libponyc/codegen/genlib.c
@@ -160,11 +160,15 @@ static bool link_lib(compile_t* c, const char* file_o)
   size_t len = 32 + strlen(file_lib) + strlen(file_o);
   char* cmd = (char*)pool_alloc_size(len);
 
+#if defined(PLATFORM_IS_MACOSX)
+  snprintf(cmd, len, "/usr/bin/ar -rcs %s %s", file_lib, file_o);
+#else
   snprintf(cmd, len, "ar -rcs %s %s", file_lib, file_o);
+#endif
 
   if(system(cmd) != 0)
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: %s", cmd);
     pool_free_size(len, cmd);
     return false;
   }
@@ -179,7 +183,7 @@ static bool link_lib(compile_t* c, const char* file_o)
 
   if(!vcvars_get(&vcvars))
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: no vcvars");
     return false;
   }
 
@@ -191,7 +195,7 @@ static bool link_lib(compile_t* c, const char* file_o)
 
   if(system(cmd) == -1)
   {
-    errorf(NULL, "unable to link");
+    errorf(NULL, "unable to link: %s", cmd);
     pool_free_size(len, cmd);
     return false;
   }


### PR DESCRIPTION
make install should be forced

it should not depend on already existing buildir binaries,
rather on the targets. simpliest is to enforce to copy them.

also support verbose=1 for it
