### PR TITLE
examples: various

### DIFF
--- a/examples/echo/echo.pony
+++ b/examples/echo/echo.pony
@@ -7,15 +7,15 @@ actor Main
 class Listener is TCPListenNotify
   let _env: Env
   var _host: String = ""
-  var _service: String = ""
+  var _port: String = ""
 
   new iso create(env: Env) =>
     _env = env
 
   fun ref listening(listen: TCPListener ref) =>
     try
-      (_host, _service) = listen.local_address().name()
-      _env.out.print("listening on " + _host + ":" + _service)
+      (_host, _port) = listen.local_address().name()
+      _env.out.print("listening on " + _host + ":" + _port)
     else
       _env.out.print("couldn't get local address")
       listen.close()

--- a/examples/yield/main.pony
+++ b/examples/yield/main.pony
@@ -195,7 +195,7 @@ actor Main
     var err : Bool = false 
 
     let options = Options(env) +
-      ("punk", "l", None) +
+      ("punk", "p", None) +
       ("lonely", "l", None) +
       ("bench", "b", I64Argument) +
       ("debug", "d", None)


### PR DESCRIPTION
yield example: fix short -p option
but short options do not work at all anymore

echo example: rename service to port