### PR TITLE
fix short options processing

### DIFF
--- a/packages/options/options.pony
+++ b/packages/options/options.pony
@@ -81,6 +81,9 @@ class Options is Iterator[(ParsedOption | ParseError | None)]
       if matched.size() == 0 then
         _arguments.delete(_index)
       end
+      if (matched.size() == 1) and (matched(0) == '-') then
+        _arguments.delete(_index)
+      end
     end
 
   fun ref _select(candidate: String ref, start: ISize, offset: ISize,

--- a/packages/options/test.pony
+++ b/packages/options/test.pony
@@ -64,6 +64,8 @@ class iso _TestShortOptions is UnitTest
       | ("none", var arg: None) => none = true
       | ("i64", var arg: I64) => i64 = arg
       | ("f64", var arg: F64) => f64 = arg
+      else
+        h.assert_failed("Invalid option reported")
       end
     end
 


### PR DESCRIPTION
we need to strip the matched part of the short option but we forgot with the last remaining "-" string to delete the argument, so that the next iterator will use the correct size