### PR TITLE
Correct String.size documentation.

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -133,7 +133,7 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
 
   fun size(): USize =>
     """
-    Returns the length of the string.
+    Returns the size of the String in bytes
     """
     _size
 


### PR DESCRIPTION
Says it returns the length of the String,
which one would assume is the total number
of characters. However, per conversation with
Sylvan, it in fact returns the number of bytes
that make up the string.